### PR TITLE
Make phone and email unique identifiers, instead of name

### DIFF
--- a/src/main/java/seedu/trackbeau/logic/commands/customer/EditCustomerCommand.java
+++ b/src/main/java/seedu/trackbeau/logic/commands/customer/EditCustomerCommand.java
@@ -94,10 +94,17 @@ public class EditCustomerCommand extends Command {
 
         Customer customerToEdit = lastShownList.get(index.getZeroBased());
         Customer editedCustomer = createEditedCustomer(customerToEdit, editCustomerDescriptor);
-
-        if (customerToEdit.isSameItem(editedCustomer) && model.hasCustomer(editedCustomer)) {
+        if (customerToEdit.isDifferentItemFromOriginal(editedCustomer) && model.hasCustomer(editedCustomer)) {
             throw new CommandException(MESSAGE_DUPLICATE_CUSTOMER);
         }
+
+        /*if (customerToEdit.isSameItem(editedCustomer) || model.hasCustomer(editedCustomer) {
+            throw new CommandException(MESSAGE_DUPLICATE_CUSTOMER
+                    + " "  + hasSameName + " " + hasSameEmail + " " + hasSamePhoneNumber);
+        }*/
+        //if have diff email, same phone, they are still considered to be the same person
+        //if model has this customer with same p or e, than there would be a clash
+        //problem: they should be considered a different person so if email or phone is different, return different
 
         model.setCustomer(customerToEdit, editedCustomer);
         model.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);

--- a/src/main/java/seedu/trackbeau/logic/commands/customer/EditCustomerCommand.java
+++ b/src/main/java/seedu/trackbeau/logic/commands/customer/EditCustomerCommand.java
@@ -95,7 +95,7 @@ public class EditCustomerCommand extends Command {
         Customer customerToEdit = lastShownList.get(index.getZeroBased());
         Customer editedCustomer = createEditedCustomer(customerToEdit, editCustomerDescriptor);
 
-        if (!customerToEdit.isSameItem(editedCustomer) && model.hasCustomer(editedCustomer)) {
+        if (customerToEdit.isSameItem(editedCustomer) && model.hasCustomer(editedCustomer)) {
             throw new CommandException(MESSAGE_DUPLICATE_CUSTOMER);
         }
 

--- a/src/main/java/seedu/trackbeau/model/customer/Birthdate.java
+++ b/src/main/java/seedu/trackbeau/model/customer/Birthdate.java
@@ -10,7 +10,7 @@ import java.time.format.DateTimeParseException;
 public class Birthdate {
     public static final String MESSAGE_CONSTRAINTS = "Birthdate should follow dd-mm-yyyy and be valid date.";
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
-    private static final String EMPTY_DATE = "01-01-1000"; //impossible date
+    public static final String EMPTY_DATE = "01-01-1000"; //impossible date
     public final LocalDate value;
 
 
@@ -41,11 +41,7 @@ public class Birthdate {
 
     @Override
     public String toString() {
-        if (this.equals(new Birthdate(EMPTY_DATE))) {
-            return "Birthday data not available.";
-        } else {
-            return formatter.format(value);
-        }
+        return formatter.format(value);
     }
 
     @Override

--- a/src/main/java/seedu/trackbeau/model/customer/Birthdate.java
+++ b/src/main/java/seedu/trackbeau/model/customer/Birthdate.java
@@ -8,9 +8,9 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
 public class Birthdate {
+    public static final String EMPTY_DATE = "01-01-1000"; //impossible date
     public static final String MESSAGE_CONSTRAINTS = "Birthdate should follow dd-mm-yyyy and be valid date.";
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
-    public static final String EMPTY_DATE = "01-01-1000"; //impossible date
     public final LocalDate value;
 
 

--- a/src/main/java/seedu/trackbeau/model/customer/Customer.java
+++ b/src/main/java/seedu/trackbeau/model/customer/Customer.java
@@ -100,7 +100,7 @@ public class Customer implements UniqueListItem {
     }
 
     /**
-     * Returns true if both customers have the same name.
+     * Returns true if both customers have the same name, phone number and email.
      * This defines a weaker notion of equality between two customers.
      */
     public boolean isSameItem(UniqueListItem other) {
@@ -113,9 +113,22 @@ public class Customer implements UniqueListItem {
         }
 
         Customer otherCustomer = (Customer) other;
-        return otherCustomer.getName().equals(getName());
+        return hasSameIdentity(otherCustomer);
     }
 
+    /**
+     * Returns true if two customers have same name or same phone number or same email
+     * @param otherCustomer
+     */
+    boolean hasSameIdentity(Customer otherCustomer) {
+        boolean hasSameName = otherCustomer.getName().equals(getName());
+        boolean hasSamePhoneNumber = otherCustomer.getPhone().equals(getPhone());
+        boolean hasSameEmail = otherCustomer.getEmail().equals(getEmail());
+        if (hasSameEmail || hasSameName || hasSamePhoneNumber) {
+            return true;
+        }
+        return false;
+    }
     /**
      * Returns true if both customers have the same identity and data fields.
      * This defines a stronger notion of equality between two customers.

--- a/src/main/java/seedu/trackbeau/model/customer/Customer.java
+++ b/src/main/java/seedu/trackbeau/model/customer/Customer.java
@@ -100,7 +100,7 @@ public class Customer implements UniqueListItem {
     }
 
     /**
-     * Returns true if both customers have the same name, phone number and email.
+     * Returns true if both customers have the same phone number and email.
      * This defines a weaker notion of equality between two customers.
      */
     public boolean isSameItem(UniqueListItem other) {
@@ -117,18 +117,38 @@ public class Customer implements UniqueListItem {
     }
 
     /**
+     * Returns true if edited customer has changed phone or email fields.
+     */
+    public boolean isDifferentItemFromOriginal(UniqueListItem other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Customer)) {
+            return false;
+        }
+
+        Customer otherCustomer = (Customer) other;
+        boolean hasSamePhoneNumber = otherCustomer.getPhone().equals(getPhone());
+        boolean hasSameEmail = otherCustomer.getEmail().equals(getEmail());
+        return !(hasSamePhoneNumber && hasSameEmail);
+    }
+
+    /**
      * Returns true if two customers have same name or same phone number or same email
      * @param otherCustomer
      */
     boolean hasSameIdentity(Customer otherCustomer) {
-        boolean hasSameName = otherCustomer.getName().equals(getName());
         boolean hasSamePhoneNumber = otherCustomer.getPhone().equals(getPhone());
         boolean hasSameEmail = otherCustomer.getEmail().equals(getEmail());
-        if (hasSameEmail || hasSameName || hasSamePhoneNumber) {
+        if (hasSameEmail || hasSamePhoneNumber) {
+            //if person has diff email, same phone, they are considered to be same person
+            //if person has diff phone, same email, they are considered to be the same person
             return true;
         }
         return false;
     }
+
     /**
      * Returns true if both customers have the same identity and data fields.
      * This defines a stronger notion of equality between two customers.

--- a/src/main/java/seedu/trackbeau/ui/CustomerCard.java
+++ b/src/main/java/seedu/trackbeau/ui/CustomerCard.java
@@ -1,5 +1,7 @@
 package seedu.trackbeau.ui;
 
+import static seedu.trackbeau.model.customer.Birthdate.EMPTY_DATE;
+
 import java.util.Comparator;
 
 import javafx.fxml.FXML;
@@ -75,7 +77,7 @@ public class CustomerCard extends UiPart<Region> {
         } else {
             hairType.setManaged(false);
         }
-        if (customer.getBirthdate().toString() != "Birthday data not available.") {
+        if (!customer.getBirthdate().value.equals(EMPTY_DATE)) {
             birthDate.setText("Birthday: " + customer.getBirthdate().toString());
         } else {
             birthDate.setManaged(false);

--- a/src/test/data/JsonSerializableTrackBeauTest/duplicateCustomerTrackBeau.json
+++ b/src/test/data/JsonSerializableTrackBeauTest/duplicateCustomerTrackBeau.json
@@ -14,7 +14,7 @@
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
-    "email": "pauline@example.com",
+    "email": "alice@example.com",
     "address": "4th street",
     "skinType": "oily",
     "hairType": "dry",

--- a/src/test/java/seedu/trackbeau/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/trackbeau/logic/commands/CommandTestUtil.java
@@ -172,11 +172,11 @@ public class CommandTestUtil {
     public static void assertCommandFailure(Command command, Model actualModel, String expectedMessage) {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
-        TrackBeau expectedAddressBook = new TrackBeau(actualModel.getTrackBeau());
+        TrackBeau expectedTrackbeau = new TrackBeau(actualModel.getTrackBeau());
         List<Customer> expectedFilteredList = new ArrayList<>(actualModel.getFilteredCustomerList());
 
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
-        assertEquals(expectedAddressBook, actualModel.getTrackBeau());
+        assertEquals(expectedTrackbeau, actualModel.getTrackBeau());
         assertEquals(expectedFilteredList, actualModel.getFilteredCustomerList());
     }
     /**

--- a/src/test/java/seedu/trackbeau/logic/commands/EditCustomerCommandTest.java
+++ b/src/test/java/seedu/trackbeau/logic/commands/EditCustomerCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_SERVICE_BOB;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_STAFF_AMY;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -56,12 +55,14 @@ public class EditCustomerCommandTest {
         Index indexLastCustomer = Index.fromOneBased(model.getFilteredCustomerList().size());
         Customer lastCustomer = model.getFilteredCustomerList().get(indexLastCustomer.getZeroBased());
 
+        //amy cannot clash phone number or email with bob but they can have the same name
+
         CustomerBuilder customerInList = new CustomerBuilder(lastCustomer);
-        Customer editedCustomer = customerInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withStaffs(VALID_STAFF_AMY).withServices(VALID_SERVICE_BOB).build();
+        Customer editedCustomer = customerInList.withName(VALID_NAME_BOB)
+                .withStaffs(VALID_STAFF_AMY).withServices(VALID_SERVICE_BOB).build();
 
         EditCustomerDescriptor descriptor = new EditCustomerDescriptorBuilder().withName(VALID_NAME_BOB)
-            .withPhone(VALID_PHONE_BOB).withStaffs(VALID_STAFF_AMY).withServices(VALID_SERVICE_BOB).build();
+                .withStaffs(VALID_STAFF_AMY).withServices(VALID_SERVICE_BOB).build();
         EditCustomerCommand editCustomerCommand = new EditCustomerCommand(indexLastCustomer, descriptor);
 
         String expectedMessage = String.format(EditCustomerCommand.MESSAGE_EDIT_CUSTOMER_SUCCESS, editedCustomer);
@@ -94,7 +95,11 @@ public class EditCustomerCommandTest {
     public void execute_noFieldSpecifiedUnfilteredList_success() {
         EditCustomerCommand editCustomerCommand =
             new EditCustomerCommand(INDEX_FIRST_CUSTOMER, new EditCustomerCommand.EditCustomerDescriptor());
+        System.out.println(editCustomerCommand.toString());
+
         Customer editedCustomer = model.getFilteredCustomerList().get(INDEX_FIRST_CUSTOMER.getZeroBased());
+
+        System.out.println(editedCustomer.toString());
 
         String expectedMessage = String.format(EditCustomerCommand.MESSAGE_EDIT_CUSTOMER_SUCCESS, editedCustomer);
 

--- a/src/test/java/seedu/trackbeau/model/customer/CustomerTest.java
+++ b/src/test/java/seedu/trackbeau/model/customer/CustomerTest.java
@@ -4,11 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_ALLERGY_BOB;
+import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_BIRTHDATE_BOB;
+import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_HAIR_TYPE_BOB;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_REG_DATE_BOB;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_SERVICE_AMY;
+import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_SERVICE_BOB;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_SKIN_TYPE_BOB;
 import static seedu.trackbeau.logic.commands.CommandTestUtil.VALID_STAFF_BOB;
 import static seedu.trackbeau.testutil.Assert.assertThrows;
@@ -35,22 +40,32 @@ public class CustomerTest {
         // null -> returns false
         assertFalse(ALICE.isSameItem(null));
 
-        // same name, all other attributes different -> returns true
-        Customer editedAlice = new CustomerBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withStaffs(VALID_STAFF_BOB).build();
+        // same name, same email, same phone, all other attributes different -> returns true
+        Customer editedAlice = new CustomerBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withStaffs(VALID_STAFF_BOB)
+                .withBirthdate(VALID_BIRTHDATE_BOB).withRegistrationDate(VALID_REG_DATE_BOB)
+                .withAllergies(VALID_ALLERGY_BOB).withServices(VALID_SERVICE_BOB).build();
         assertTrue(ALICE.isSameItem(editedAlice));
 
-        // different name, all other attributes same -> returns false
-        editedAlice = new CustomerBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        // different name, different phone, different email, all other attributes same -> returns false
+        editedAlice = new CustomerBuilder(ALICE).withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).build();
         assertFalse(ALICE.isSameItem(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
-        Customer editedBob = new CustomerBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        // name differs in case, different email, different phone,
+        // all other attributes same -> returns false
+        Customer editedBob = new CustomerBuilder(BOB)
+                .withName(VALID_NAME_BOB.toLowerCase())
+                .withPhone(VALID_PHONE_AMY)
+                .withEmail(VALID_EMAIL_AMY)
+                .build();
         assertFalse(BOB.isSameItem(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new CustomerBuilder(BOB).withName(nameWithTrailingSpaces).build();
+        editedBob = new CustomerBuilder(BOB).withName(nameWithTrailingSpaces)
+                .withPhone(VALID_PHONE_AMY)
+                .withEmail(VALID_EMAIL_AMY)
+                .build();
         assertFalse(BOB.isSameItem(editedBob));
     }
 


### PR DESCRIPTION
Customers can have the same name as some names are very common, but if they have different phone or email, then they should be considered different people

Users cannot add customers with same phone or email and they cannot edit such that two customer have same phone or email

Bug relating to birthdate that caused data to not be stored in correct format was fixed